### PR TITLE
Eject macOs installer disk if its still open

### DIFF
--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -139,9 +139,11 @@ function installerExists()
 #
 # Main script code
 #
-# See if we can find either the ElCapitan or the 10.12 installer.
+# Eject installer disk in case it was opened after download from App Store
+hdiutil info | grep /dev/disk | grep partition | cut -f 1 | xargs hdiutil detach -force
+
+# See if we can find either the ElCapitan or the Sierra installer.
 # If successful, then create the iso file from the installer.
-#
 
 installerExists "Install macOS Sierra.app"
 result=$?


### PR DESCRIPTION
After re-downloading the Sierra installer app from the App Store (as per README instructions), the installer was auto-launched for me. I instinctually closed it and ran the `prepare-iso.sh` script, which kept failing at the `hdiutil attach` commands in the `createISO` function. Obviously, I had to manually eject the installer disk in order to continue.

In case this happens to someone else, I've added a bit that (admittedly somewhat blindly) ejects the disk before creating the ISO.

Let me know if this is an awful idea for some reason :)