### PR TITLE
Add support for High Sierra 10.13 and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # macOS VirtualBox VM Instructions
 
-Current macOS version: *Sierra (10.12)*, tested with VirtualBox *5.1.6 r110634*
+Current macOS version: *High Sierra (10.13)*, tested with VirtualBox *5.1.28 r117968*
 
 To build a VM running macOS, follow the directions below:
 
-  1. Download the installer from Mac App Store (it should be available in the 'Purchases' section if you've acquired it previously). The installer will be placed in your Applications folder. (Should work for Yosemite, El Capitan and Sierra - 10.10-10.12.).
+  1. Download the installer from Mac App Store (it should be available in the 'Purchases' section if you've acquired it previously). The installer will be placed in your Applications folder. (Should work for Yosemite, El Capitan, Sierra and High Sierra - 10.10-10.13.).
       - **Note**: On newer hardware, you might not be able to download older OS releases that Apple doesn't support on the newer hardware (e.g. the 2016 MacBook Pro can only download 10.12 Sierra or later). In this case, you need to use an older Mac to download the older OS.
   2. Make the script executable and run it: `chmod +x prepare-iso.sh && ./prepare-iso.sh`.
 
@@ -37,6 +37,7 @@ To build a VM running macOS, follow the directions below:
 - The default Video Memory of 16MB is far below Apple's official requirement of 128MB. Increasing this value may help if you run into problems and is also the most effective performance tuning.
 - Depending on your hardware, you may also want to increase RAM and the share of CPU power the VM is allowed to use.
 - When the installation is complete, and you have a fresh new macOS VM, you can shut it down and create a snapshot. This way, you can go back to the initial state in the future. I use this technique to test the [`mac-dev-playbook`](https://github.com/geerlingguy/mac-dev-playbook), which I use to set up and configure my own Mac workstation for web and app development.
+- If for High Sierra you can not find the VirtualBox disk created inside the Disk Utility select `View -> Show All Devices` and format the newly visible device ([Source: tinyapps.org](https://tinyapps.org/blog/mac/201710010700_high_sierra_disk_utility.html)).
 
 ## Larger VM Screen Resolution
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ To build a VM running macOS, follow the directions below:
 - Depending on your hardware, you may also want to increase RAM and the share of CPU power the VM is allowed to use.
 - When the installation is complete, and you have a fresh new macOS VM, you can shut it down and create a snapshot. This way, you can go back to the initial state in the future. I use this technique to test the [`mac-dev-playbook`](https://github.com/geerlingguy/mac-dev-playbook), which I use to set up and configure my own Mac workstation for web and app development.
 - If for High Sierra you can not find the VirtualBox disk created inside the Disk Utility select `View -> Show All Devices` and format the newly visible device ([Source: tinyapps.org](https://tinyapps.org/blog/mac/201710010700_high_sierra_disk_utility.html)).
+- If for High Sierra you encounter boot / EFI problems, restart the VM and hit `F12` to get to the VirtualBox boot manager.  Select **EFI In-Terminal Shell** and run:
+```bash
+Shell> fs1:
+FS1:\> cd "macOS Install Data"
+FS1:\macOS Install Data\> cd "Locked Files"
+FS1:\macOS Install Data\Locked Files\> cd "Boot Files"
+FS1:\macOS Install Data\Locked Files\Boot Files\> boot.efi
+```
 
 ## Larger VM Screen Resolution
 

--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -37,6 +37,7 @@ function createISO()
       echo $ hdiutil attach /Applications/"${installerAppName}"/Contents/SharedSupport/InstallESD.dmg -noverify -nobrowse -mountpoint /Volumes/install_app
       hdiutil attach /Applications/"${installerAppName}"/Contents/SharedSupport/InstallESD.dmg -noverify -nobrowse -mountpoint /Volumes/install_app
       error=$?
+      installerAppName="/Applications/${installerAppName}"
     else
       echo Installer Not found!
       error=1

--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -63,40 +63,40 @@ function createISO()
     echo Restore the Base System into the ${isoName} ISO image
     echo --------------------------------------------------------------------------
     if [ "${isoName}" == "HighSierra" ] ; then
-		  echo $ time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-    	time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-	  else
-		  echo $ asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-    	asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-	  fi
-	
+      echo $ time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+      time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+    else
+      echo $ asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+      asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+    fi
+
     echo
     echo Remove Package link and replace with actual files
     echo --------------------------------------------------------------------------
-	  if [ "${isoName}" == "HighSierra" ] ; then
-	    echo $ time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-    	time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-	  else	
-    	echo $ rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
-    	rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
-    	echo $ cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-    	cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-	  fi
-	
+    if [ "${isoName}" == "HighSierra" ] ; then
+      echo $ time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+      time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+    else
+      echo $ rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
+      rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
+      echo $ cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+      cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+    fi
+
     echo
     echo Copy macOS ${isoName} installer dependencies
     echo --------------------------------------------------------------------------
-	  if [ "${isoName}" == "HighSierra" ] ; then
-	    echo $ ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    	ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    	echo $ time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
-    	time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg	
-	  else
-    	echo $ cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    	cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    	echo $ cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
-    	cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
-	  fi
+    if [ "${isoName}" == "HighSierra" ] ; then
+      echo $ ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+      ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+      echo $ time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+      time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+    else
+      echo $ cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+      cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+      echo $ cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+      cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+    fi
 
     echo
     echo Unmount the installer image

--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -160,7 +160,7 @@ function installerExists()
 # Eject installer disk in case it was opened after download from App Store
 hdiutil info | grep /dev/disk | grep partition | cut -f 1 | xargs --no-run-if-empty hdiutil detach -force
 
-# See if we can find either the ElCapitan or the Sierra installer.
+# See if we can find an elligible installer.
 # If successful, then create the iso file from the installer.
 
 installerExists "Install macOS High Sierra.app"

--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
+#
+# This script will create a bootable ISO image from the installer application for
+# - El Capitan (10.11)
+# - Sierra (10.12) macOS
+# - High Sierra (10.13) macOS
 
-#
-# This script will create a bootable ISO image from the installer application for El Capitan (10.11) or the new Sierra (10.12) macOS.
-# Restructured a bit, and adapted the 10.11 script from this URL:
-# https://forums.virtualbox.org/viewtopic.php?f=22&t=77068&p=358865&hilit=elCapitan+iso#p358865
-#
 
 #
 # createISO
@@ -62,24 +62,41 @@ function createISO()
     echo
     echo Restore the Base System into the ${isoName} ISO image
     echo --------------------------------------------------------------------------
-    echo $ asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-    asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
-
+    if [ "${isoName}" == "HighSierra" ] ; then
+		  echo $ time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+    	time asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+	  else
+		  echo $ asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+    	asr restore -source /Volumes/install_app/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
+	  fi
+	
     echo
     echo Remove Package link and replace with actual files
     echo --------------------------------------------------------------------------
-    echo $ rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
-    rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
-    echo $ cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-    cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
-
+	  if [ "${isoName}" == "HighSierra" ] ; then
+	    echo $ time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+    	time ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+	  else	
+    	echo $ rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
+    	rm /Volumes/OS\ X\ Base\ System/System/Installation/Packages
+    	echo $ cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+    	cp -rp /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
+	  fi
+	
     echo
     echo Copy macOS ${isoName} installer dependencies
     echo --------------------------------------------------------------------------
-    echo $ cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
-    echo $ cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
-    cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+	  if [ "${isoName}" == "HighSierra" ] ; then
+	    echo $ ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+    	ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+    	echo $ time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+    	time ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg	
+	  else
+    	echo $ cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+    	cp -rp /Volumes/install_app/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
+    	echo $ cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+    	cp -rp /Volumes/install_app/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg
+	  fi
 
     echo
     echo Unmount the installer image
@@ -100,10 +117,10 @@ function createISO()
     hdiutil resize -size `hdiutil resize -limits /tmp/${isoName}.sparseimage | tail -n 1 | awk '{ print $1 }'`b /tmp/${isoName}.sparseimage
 
     echo
-    echo Convert the sparse bundle to ISO/CD master
+    echo Convert ${isoName} the sparse bundle to ISO/CD master
     echo --------------------------------------------------------------------------
-    echo $ hdiutil convert /tmp/${isoName}.sparseimage -format UDTO -o /tmp/${isoName}
-    hdiutil convert /tmp/${isoName}.sparseimage -format UDTO -o /tmp/${isoName}
+    echo $ time hdiutil convert /tmp/${isoName}.sparseimage -format UDTO -o /tmp/${isoName}
+    time hdiutil convert /tmp/${isoName}.sparseimage -format UDTO -o /tmp/${isoName}
 
     echo
     echo Remove the sparse bundle
@@ -140,27 +157,33 @@ function installerExists()
 # Main script code
 #
 # Eject installer disk in case it was opened after download from App Store
-hdiutil info | grep /dev/disk | grep partition | cut -f 1 | xargs hdiutil detach -force
+hdiutil info | grep /dev/disk | grep partition | cut -f 1 | xargs --no-run-if-empty hdiutil detach -force
 
 # See if we can find either the ElCapitan or the Sierra installer.
 # If successful, then create the iso file from the installer.
 
-installerExists "Install macOS Sierra.app"
+installerExists "Install macOS High Sierra.app"
 result=$?
 if [ ${result} -eq 0 ] ; then
-  createISO "Install macOS Sierra.app" "Sierra"
+  createISO "Install macOS High Sierra.app" "HighSierra"
 else
-  installerExists "Install OS X El Capitan.app"
+  installerExists "Install macOS Sierra.app"
   result=$?
   if [ ${result} -eq 0 ] ; then
-    createISO "Install OS X El Capitan.app" "ElCapitan"
+    createISO "Install macOS Sierra.app" "Sierra"
   else
-    installerExists "Install OS X Yosemite.app"
+    installerExists "Install OS X El Capitan.app"
     result=$?
     if [ ${result} -eq 0 ] ; then
-      createISO "Install OS X Yosemite.app" "Yosemite"
+      createISO "Install OS X El Capitan.app" "ElCapitan"
     else
-      echo "Could not find installer for Yosemite (10.10), El Capitan (10.11) or Sierra (10.12)."
+      installerExists "Install OS X Yosemite.app"
+      result=$?
+      if [ ${result} -eq 0 ] ; then
+        createISO "Install OS X Yosemite.app" "Yosemite"
+      else
+        echo "Could not find installer for Yosemite (10.10), El Capitan (10.11), Sierra (10.12) or High Sierra (10.13)."
+      fi
     fi
   fi
 fi


### PR DESCRIPTION
Based on #37 and from some of the things outlined in #28.

Additions include new section in troubleshooting and fixed formatting (tabs to spaces) on the `prepare-iso.sh` script.

Fixes #28.