### PR TITLE
Update README to include notes on EFI Graphics Resolution command

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Replace `[VM_NAME]` with the name of your Virtual Machine.  Replace `N` with one
 
 The video mode can only be changed when the VM is powered off and remains persistent until changed. See more details in [this forum discussion](https://forums.virtualbox.org/viewtopic.php?f=22&t=54030).
 
+If you're still having trouble after trying all of the above, and for VirtualBox 5.2+, the following command may also help ([see documentation here](https://www.virtualbox.org/manual/ch03.html#efividmode)):
+
+          VBoxManage setextradata "[VM_NAME]" VBoxInternal2/EfiGraphicsResolution HxV
+
+where `H` is the height and `W` is the width of your display, e.g. 1440x900.
+
 ## Notes
 
   - Code for this example mostly comes from VirtualBox forums and [this article](http://sqar.blogspot.de/2014/10/installing-yosemite-in-virtualbox.html).


### PR DESCRIPTION
The script got me up and running in no time with a new El Capitan guest on my Sierra host.

But I struggled with resolution until I came across this command from some online video comments. It was in the [VirtualBox documentation](https://www.virtualbox.org/manual/ch03.html#efividmode) and this was the only thing that worked for me. 

The `extradata` for my host now looks like:

```
Key: GUI/Fullscreen, Value: true
Key: GUI/HiDPI/UnscaledOutput, Value: true
Key: GUI/LastCloseAction, Value: PowerOff
Key: GUI/LastNormalWindowPosition, Value: 139,44,1024,789
Key: VBoxInternal2/EfiGopMode, Value: 4
Key: VBoxInternal2/EfiGraphicsResolution, Value: 1440x900
```

Thanks!