### PR TITLE
Update script and instructions for Mojave

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ To build a VM running macOS, follow the directions below:
   - If for High Sierra you can not find the VirtualBox disk created inside the Disk Utility select `View -> Show All Devices` and format the newly visible device ([Source: tinyapps.org](https://tinyapps.org/blog/mac/201710010700_high_sierra_disk_utility.html)).
   - If for High Sierra you encounter boot / EFI problems, restart the VM and hit `F12` to get to the VirtualBox boot manager. Select **EFI In-Terminal Shell** and run:
 
-          ```bash
           Shell> fs1:
           FS1:\> cd "macOS Install Data"
           FS1:\macOS Install Data\> cd "Locked Files"
           FS1:\macOS Install Data\Locked Files\> cd "Boot Files"
           FS1:\macOS Install Data\Locked Files\Boot Files\> boot.efi
-          ```
+
+  - If keyboard and mouse do not work inside the VM:
+    1. Ensure the VirtualBox Extension Pack is installed.
+    2. In the VM settings, under `Ports > USB`, select `USB 3.0 (xHCI) Control`.
 
 ## Larger VM Screen Resolution
 

--- a/prepare-iso.sh
+++ b/prepare-iso.sh
@@ -12,6 +12,9 @@
 # Inputs:  $1 = The name of the installer - located in your Applications folder or in your local folder/PATH.
 #          $2 = The Name of the ISO you want created.
 #
+
+set -e
+
 function createISO()
 {
   if [ $# -eq 2 ] ; then
@@ -59,7 +62,7 @@ function createISO()
     echo
     echo Restore the Base System into the ${isoName} ISO image
     echo --------------------------------------------------------------------------
-    if [ "${isoName}" == "HighSierra" ] ; then
+    if [ "${isoName}" == "HighSierra" ] || [ "${isoName}" == "Mojave" ] ; then
       echo $ asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
       asr restore -source "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg -target /Volumes/install_build -noprompt -noverify -erase
     else
@@ -70,7 +73,7 @@ function createISO()
     echo
     echo Remove Package link and replace with actual files
     echo --------------------------------------------------------------------------
-    if [ "${isoName}" == "HighSierra" ] ; then
+    if [ "${isoName}" == "HighSierra" ] || [ "${isoName}" == "Mojave" ] ; then
       echo $ ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
       ditto -V /Volumes/install_app/Packages /Volumes/OS\ X\ Base\ System/System/Installation/
     else
@@ -83,7 +86,7 @@ function createISO()
     echo
     echo Copy macOS ${isoName} installer dependencies
     echo --------------------------------------------------------------------------
-    if [ "${isoName}" == "HighSierra" ] ; then
+    if [ "${isoName}" == "HighSierra" ] || [ "${isoName}" == "Mojave" ] ; then
       echo $ ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
       ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.chunklist /Volumes/OS\ X\ Base\ System/BaseSystem.chunklist
       echo $ ditto -V "${installerAppName}"/Contents/SharedSupport/BaseSystem.dmg /Volumes/OS\ X\ Base\ System/BaseSystem.dmg


### PR DESCRIPTION
This PR makes a few modifications to the script to make it work for Mojave. I also added `set -e` to the top of the script to make it exit if any any errors occur.

With these changes I was able to complete a Mojave installation inside the VM (both the installation from the iso and the post-reboot installation). But after rebooting the VM I was stuck in the EFI shell and the Mojave volume was not available. I had encountered this with a previous attempt where I had formatted the disk as APFS but this time I had formatted as "Mac OS Extended (Journaled)" so I'm not sure why the volume vanished.

At this point I tried https://github.com/AlexanderWillner/runMacOSinVirtualBox and that succeeded. Perhaps for Mojave we should just point people to that project?